### PR TITLE
Clear empty tempo events in removeAcceleration

### DIFF
--- a/src/MidiRoll.cpp
+++ b/src/MidiRoll.cpp
@@ -318,6 +318,7 @@ void MidiRoll::removeAcceleration (void) {
 		}
 		mr[0][i].clear();
 	}
+	MidiFile::removeEmpties();
 	// Need to add tempo = 60 at tick 0
 	MidiFile::addTempo(0, 0, 60.0);
 	MidiFile::sortTrack(0);


### PR DESCRIPTION
The current version of the code, when removing any pre-existing acceleration emulation from the input MIDI file by clearing out any tempo messages in track 0, doesn't actually remove the messages from the track; it just clears their contents.

This problem was not previously noticed because the acceleration emulation code always would rewrite the tempo messages at the same ticks as the cleared tempo messages (0, 3600, 7200, etc.) -- essentially overwriting the blank messages that were still there. If however the tempo messages of the input note MIDI file are on different ticks than the new messages added in `applyAcceleration()`, then the tempo events of the resulting expression MIDI file end up being seriously mangled.

Running `MidiFile::removeEmpties()` in `removeAcceleration()` after clearing the tempo messages (and before running `applyAcceleration()`) avoids this problem, and ensures that the previously added tempo messages have been truly removed.