### PR TITLE
Replace distance-based acceleration emulation with time-based emulation

### DIFF
--- a/include/Expressionizer.h
+++ b/include/Expressionizer.h
@@ -86,7 +86,7 @@ class Expressionizer {
 		double        getFastDecrescendo           (void);
 		double        getLeftRightDiff             (void);
 
-		void          setAcceleration              (double inches, double percent);
+		void          setAcceleration              (double accelFtPerMin2);
 
 
 	protected:
@@ -122,8 +122,9 @@ class Expressionizer {
 
 		// version
 		std::string m_version;
-		double      m_inches  = 12.0;
-		double      m_percent = 0.22;
+
+		// default feet/minute^2 acceleration for all except red Welte rolls
+		double m_accelFtPerMin2 = 0.2;
 
 		// left_adjust: reduce loudness of bass register (for attack velocities)
 		int left_adjust       = -5;

--- a/include/Expressionizer.h
+++ b/include/Expressionizer.h
@@ -118,7 +118,7 @@ class Expressionizer {
 		double tracker_fraction = 0.75;               // for hole extension, 75% of the tracker bar diameter
 
 		bool trackbar_correction_done = false;
-		bool delete_expresison_tracks = false;
+		bool delete_expression_tracks = false;
 
 		// version
 		std::string m_version;

--- a/include/MidiRoll.h
+++ b/include/MidiRoll.h
@@ -48,8 +48,7 @@ class MidiRoll : public MidiFile {
 
 		// acceleration emulation:
 		void                    removeAcceleration (void);
-		void                    applyAcceleration  (double inches,
-		                                            double percent);
+		void                    applyAcceleration  (double accelFtPerMin2);
       // tick conversions:
 		void                    convertToMillisecondTicks (void);
 

--- a/src/Expressionizer.cpp
+++ b/src/Expressionizer.cpp
@@ -565,7 +565,7 @@ void Expressionizer::updateMidiTimingInfo(void) {
 //
 
 bool Expressionizer::writeMidiFile(std::string filename) {
-    if ((midi_data.getTrackCount() == 5) && delete_expresison_tracks) {
+    if ((midi_data.getTrackCount() == 5) && delete_expression_tracks) {
         midi_data.deleteTrack(4);
         midi_data.deleteTrack(3);
     }
@@ -1660,7 +1660,7 @@ double Expressionizer::getPunchExtensionFraction(void) {
 //
 
 void Expressionizer::removeExpressionTracksOnWrite(void) {
-    delete_expresison_tracks = true;
+    delete_expression_tracks = true;
 }
 
 

--- a/src/Expressionizer.cpp
+++ b/src/Expressionizer.cpp
@@ -204,19 +204,15 @@ Expressionizer::~Expressionizer(void) {
 
 //////////////////////////////
 //
-// Expressionizer::setAcceleration -- Set acceleration by xx percent every xx inches.
+// Expressionizer::setAcceleration -- Set acceleration in feet per minute^2.
 //
 
-void Expressionizer::setAcceleration(double inches, double percent) {
-    if (inches <= 0.0) {
-        return;
-    }
-    if (percent <= 0.0) {
+void Expressionizer::setAcceleration(double accelFtPerMin2) {
+    if (accelFtPerMin2 < 0.0) {
         return;
     }
 
-    m_inches = inches;
-    m_percent = percent;
+    m_accelFtPerMin2 = accelFtPerMin2;
 }
 
 
@@ -228,7 +224,7 @@ void Expressionizer::setAcceleration(double inches, double percent) {
 
 void Expressionizer::addExpression(void) {
     setPan();
-    midi_data.applyAcceleration(m_inches, m_percent);
+    midi_data.applyAcceleration(m_accelFtPerMin2);
     if (roll_type == "red") {
         calculateRedWelteExpression("left_hand");
         calculateRedWelteExpression("right_hand");
@@ -611,14 +607,9 @@ void Expressionizer::addMetadata(void) {
     }
 
     ss.str("");
-    ss << "\t\t" << m_inches;
+    ss << "\t\t" << m_accelFtPerMin2;
     sss = ss.str();
-    midi_data.setMetadata("ACCEL_INCH", sss);
-
-    ss.str("");
-    ss << "\t" << m_percent;
-    sss = ss.str();
-    midi_data.setMetadata("ACCEL_PERCENT", sss);
+    midi_data.setMetadata("ACCEL_FT/MIN^2", sss);
 
     if (trackbar_correction_done) {
         int correction = int(getTrackerbarDiameter() * getPunchExtensionFraction() + 0.5);

--- a/tools/midi2exp.cpp
+++ b/tools/midi2exp.cpp
@@ -44,6 +44,7 @@ int main(int argc, char** argv) {
 	// options.define("wmf|welte-mezzo-forte=d:60.0", "(Red Welte)");
 	// options.define("wf|welte-forte=d:89.0", "(Red Welte)");
 	// options.define("wl|welte-loud=d:70.0", "(Red Welte)");
+	// options.define("ac|accel-ft-per-min2=d:0.3147", "acceleration in feet per minute^2");
 
 	// green
 	options.define("sd|slow-decay-rate=d:2366", "Slow decay rate (Red Welte)"); // 2380
@@ -55,8 +56,7 @@ int main(int argc, char** argv) {
 	options.define("wl|welte-loud=d:70.0", "Loud velocity");
 
 	options.define("v|version=s", "Add version number metadata");
-	options.define("i|ai|acceleration-inches=d:12.0", "acceleration update for every xx inches");
-	options.define("p|ap|acceleration-percent=d:0.22", "acceleration percent (based on every x inches)");
+	options.define("ac|accel-ft-per-min2=d:0.2", "acceleration in feet per minute^2");
 
 	options.process(argc, argv);
 
@@ -90,10 +90,12 @@ int main(int argc, char** argv) {
 		creator.readMidiFile(options.getArg(1));
 	}
 
+	// default acceleration is 0.2, except for red Welte rolls
 	// green welte default tempo is 72.2222 if not specified.
 	if (options.getBoolean("red-welte")) {
 		creator.setRollTempo(94.6);    //94.6
 		cout << "setting red welte tempo 94.6" << endl;
+		creator.setAcceleration(0.3147);
 	}
 	else if (options.getBoolean("green-welte")){
 		creator.setRollTempo(72.2);
@@ -147,9 +149,9 @@ int main(int argc, char** argv) {
 		creator.setVersion(options.getString("version"));
 	}
 
-	double inches = options.getDouble("acceleration-inches");
-	double percent = options.getDouble("acceleration-percent");
-	creator.setAcceleration(inches, percent);
+	if (options.getBoolean("accel-ft-per-min2")) {
+		creator.setAcceleration(options.getDouble("accel-ft-per-min2"));
+	}
 
 	creator.addExpression();
 	creator.setPianoTimbre();


### PR DESCRIPTION
The new algorithm emulates as kinematic acceleration the slight but constant increase in roll speed that occurs when the takeup spool's effective diameter increases as it accumulates new layers of paper.

The previous method increased the tempo by some percent per unit distance played (e.g., a foot) and therefore had the option to read both the unit distance (in inches) and acceleration (in percent) from the command line. The new method has just one emulation parameter, the acceleration rate in feet per minute per minute. Default values for this parameter, derived through examination of the acceleration rates of real-world player piano hardware, are provided and set according to the roll type.

At present, there is one standard acceleration rate for red Welte rolls, and another for green Welte and all others. The parameter also can be set to any value (including 0, for no emulated acceleration) via the `--ac` command-line option.