### PR TITLE
Correct soft pedal MIDI assignments for Welte red, Licensee

### DIFF
--- a/src/Expressionizer.cpp
+++ b/src/Expressionizer.cpp
@@ -114,8 +114,8 @@ void Expressionizer::setupGreenWelte(void) {
 // 4       19    Bass crescendo on
 // 5       20    Bass sforzando off
 // 6       21    Bass sforzando on
-// 7       22    Hammer rail down (Soft pedal on)
-// 8       23    Hammer rail up (Soft pedal off)
+// 7       22    Hammer rail down (Soft pedal off)
+// 8       23    Hammer rail up (Soft pedal on)
 // 9 - 88  24-66 Notes C1 to G7, 67-103 Notes G4 to G7
 // 9       24    C1
 // 10      25    C#1
@@ -147,11 +147,11 @@ void Expressionizer::setupGreenWelte(void) {
 //
 
 void Expressionizer::setupLicenseeWelte(void) {
-    // expression keys for Red Welte rolls:
+    // expression keys for Welte Licensee rolls:
     PedalOnKey     = 106;
     PedalOffKey    = 107;
-    SoftOnKey      = 21;
-    SoftOffKey     = 20;
+    SoftOnKey      = 23;
+    SoftOffKey     = 22;
     roll_type      = "licensee";
     slow_decay_rate  = 2163; // test rolls shows 2163ms for treble SC from min to MF
     fastC_decay_rate = 220;  // test roll shows around 193ms-237ms from min to MF
@@ -1840,6 +1840,7 @@ void Expressionizer::printVelocity() {
 
 ostream& Expressionizer::printExpression(ostream& out, bool extended) {
     int maxi = std::min(exp_bass.size(), exp_treble.size());
+    out << "ms\tb_vel\tb_slowC\tb_fastC\tb_fastD\tt_vel\tt_slowC\tt_fastC\tt_fastD" << endl;
     for (int i=0; i<maxi; i++) {
         out << i << "\t" << exp_bass[i];
         if (extended) {
@@ -1849,9 +1850,9 @@ ostream& Expressionizer::printExpression(ostream& out, bool extended) {
         }
         out << "\t" << exp_treble[i];
         if (extended) {
-            out << "\t" << isSlowC_bass[i];
-            out << "\t" << isFastC_bass[i];
-            out << "\t" << isFastD_bass[i];
+            out << "\t" << isSlowC_treble[i];
+            out << "\t" << isFastC_treble[i];
+            out << "\t" << isFastD_treble[i];
         }
         out << endl;
     }

--- a/src/Expressionizer.cpp
+++ b/src/Expressionizer.cpp
@@ -30,8 +30,8 @@ using namespace smf;
 //
 
 Expressionizer::Expressionizer(void) {
-    //setupRedWelte();  // default setup is for Red Welte rolls.
-    setupGreenWelte();
+    setupRedWelte();  // default setup is for Red Welte rolls.
+    //setupGreenWelte();
 }
 
 
@@ -54,8 +54,8 @@ void Expressionizer::setupRedWelte(void) {
     // expression keys for Red Welte rolls:
     PedalOnKey     = 106;
     PedalOffKey    = 107;
-    SoftOnKey      = 22;
-    SoftOffKey     = 23;
+    SoftOnKey      = 21;
+    SoftOffKey     = 20;
     roll_type      = "red";
     slow_decay_rate  = 2380;  //2380
     fastC_decay_rate = 300; // test roll shows around 170ms-200ms from min to MF hook


### PR DESCRIPTION
The soft pedal on/off MIDI key assignments for Welte red rolls were set to incorrect values (22 and 23, rather than 21 and 20) during the refactor of `Expressionizer.cpp` in commit https://github.com/pianoroll/midi2exp/commit/1b5fb6a2ccc78276047b0154c7866716cd43ba2c.

Also, the soft pedal on/off MIDI key assignments for Licensee rolls seem to have been incorrectly switched when they were added to `Expressionizer.cpp` -- they were set to on=22 on, off=23, but should be on=23, off=22. This conforms to the on/off control hole pattern for the other bass-side controls, and also aligns with the control hole scheme for red Welte (T-100) rolls, to which Licensee rolls conform in all other cases, so it seems unlikely (but not impossible) that only this case would deviate. Additionally, sources like [this one](https://www.mmdigest.com/Smythe/Piano_Playing_Mechanisms.pdf) (p. 198) indicate that the adjusted numbering is correct: raising the hammer rail (MIDI 23) is equivalent to depressing the soft pedal, which moves the hammers closer to the strings so the reduced travel distance will cause them to play less loudly when pressed; lowering the hammer rail (MIDI #=22) is equivalent to releasing the soft pedal, moving the hammers farther from the strings.

This PR corrects those settings and includes a couple of miscellaneous additional changes: reverting to red Welte being the default roll type for expression emulation, and correcting the output from `printExpression()`.